### PR TITLE
install dbt-postgres from PyPI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,14 +11,11 @@ deps =
 
 [testenv:{py36,py37,py38,py39,py}]
 description = rpc testing
-skip_install = true
 passenv = DBT_* POSTGRES_TEST_* PYTEST_ADDOPTS
 commands = {envpython} -m pytest {posargs}
 deps =
   -rdev-requirements.txt
-  json-rpc>=1.12,<2
-  git+https://github.com/dbt-labs/dbt.git#egg=dbt-core&subdirectory=core
-  git+https://github.com/dbt-labs/dbt.git#egg=dbt-postgres&subdirectory=plugins/postgres
+  dbt-postgres
 
 [pytest]
 env_files =


### PR DESCRIPTION
Use `dbt-postgres` from PyPI when running integration tests.