### PR TITLE
Readd single-threaded env vars

### DIFF
--- a/dbt_rpc/rpc/task_handler.py
+++ b/dbt_rpc/rpc/task_handler.py
@@ -12,7 +12,7 @@ from typing_extensions import Protocol
 from dbt.dataclass_schema import dbtClassMixin, ValidationError
 
 import dbt.exceptions
-import dbt.flags
+from dbt.flags import env_set_truthy
 import dbt.tracking
 from dbt.adapters.factory import (
     cleanup_connections, load_plugin, register_adapter,
@@ -47,6 +47,9 @@ from queue import Queue  # noqa
 
 def sigterm_handler(signum, frame):
     raise dbt.exceptions.RPCKilledException(signum)
+
+
+SINGLE_THREADED_HANDLER = env_set_truthy('DBT_SINGLE_THREADED_HANDLER')
 
 
 class BootstrapProcess(dbt.flags.MP_CONTEXT.Process):
@@ -320,7 +323,7 @@ class RequestTaskHandler(threading.Thread, TaskHandlerProtocol):
     def _single_threaded(self):
         return bool(
             self.task.args.single_threaded or
-            dbt.flags.SINGLE_THREADED_HANDLER
+            SINGLE_THREADED_HANDLER
         )
 
     @property

--- a/dbt_rpc/rpc/task_manager.py
+++ b/dbt_rpc/rpc/task_manager.py
@@ -38,6 +38,9 @@ from dbt import helper_types  # noqa
 WrappedHandler = Callable[..., Dict[str, Any]]
 
 
+SINGLE_THREADED_WEBSERVER = flags.env_set_truthy('DBT_SINGLE_THREADED_WEBSERVER')
+
+
 class UnconditionalError:
     def __init__(self, exception: dbt.exceptions.Exception):
         self.exception = dbt_error(exception)
@@ -91,7 +94,7 @@ class TaskManager:
         self.reload_manifest()
 
     def single_threaded(self):
-        return flags.SINGLE_THREADED_WEBSERVER or self.args.single_threaded
+        return SINGLE_THREADED_WEBSERVER or self.args.single_threaded
 
     def _reload_task_manager_thread(self, reloader: ManifestReloader):
         """This function can only be running once at a time, as it runs in the

--- a/dbt_rpc/task/sql_commands.py
+++ b/dbt_rpc/task/sql_commands.py
@@ -4,7 +4,7 @@ import threading
 from datetime import datetime
 from typing import Dict, Any
 
-from dbt import flags
+from dbt.flags import env_set_truthy
 from dbt.adapters.factory import get_adapter
 from dbt.clients.jinja import extract_toplevel_blocks
 from dbt.config.runtime import RuntimeConfig
@@ -24,6 +24,9 @@ from dbt.task.run import RunTask
 from .base import RPCTask
 
 
+SINGLE_THREADED_HANDLER = env_set_truthy('DBT_SINGLE_THREADED_HANDLER')
+
+
 def add_new_refs(
     manifest: Manifest,
     config: RuntimeConfig,
@@ -33,7 +36,7 @@ def add_new_refs(
     """Given a new node that is not in the manifest, insert the new node
     into it as if it were part of regular ref processing.
     """
-    if config.args.single_threaded or flags.SINGLE_THREADED_HANDLER:
+    if config.args.single_threaded or SINGLE_THREADED_HANDLER:
         manifest = manifest.deepcopy()
     # it's ok for macros to silently override a local project macro name
     manifest.macros.update(macros)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,6 @@
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-postgres&subdirectory=plugins/postgres
+
 flake8
 pytest
 pytest-xdist

--- a/tests/util.py
+++ b/tests/util.py
@@ -622,7 +622,7 @@ class ProjectDefinition:
         self._write_values(project_dir, remove, 'snapshots', self.snapshots)
 
     def write_seeds(self, project_dir, remove=False):
-        self._write_values(project_dir, remove, 'data', self.seeds)
+        self._write_values(project_dir, remove, 'seeds', self.seeds)
 
     def write_to(self, project_dir, remove=False):
         if remove:

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ passenv = DBT_* POSTGRES_TEST_* PYTEST_ADDOPTS
 commands = {envpython} -m pytest {posargs}
 deps =
   -rdev-requirements.txt
-  dbt-postgres==1.0.0b1
+  -e.
 
 [pytest]
 env_files =


### PR DESCRIPTION
While toying with related code in `flags.py` in , I not-so-wisely [removed two flags / env vars](https://github.com/dbt-labs/dbt-core/commit/4bda8c888009e520ca7a06a305d981a95b7b6308#diff-b99c74c2d09fa1ea054aa843fa3738bd7c9d39acb9c5b90ca920f0e1fcf38010L80-L81) that are still being imported and used in `dbt-rpc`. This was a breaking change, and it means that `dbt-core==1.0.0b2` and `dbt-rpc==0.1.0` are currently incompatible:

<img width="763" alt="Screenshot 2021-11-05 at 17 45 29" src="https://user-images.githubusercontent.com/13897643/140547335-23d05d0e-4c22-4fcc-b864-31722c012cbc.png">

Rather than add those vars/flags back to `dbt-core`, I think this package is actually the right place to define them longer-term. This change is backwards compatible, so we can cut a patch release (`0.1.1`) accordingly.