### PR TITLE
Disable py36 tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     env:
       TOXENV: "py"
@@ -161,7 +161,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
- Disable py36 tests, now that the `main` branch of dbt Core has officially removed support for python 3.6 (https://github.com/dbt-labs/dbt-core/pull/4223)
- We could also remove python 3.6 from this package's metadata and bump `python_requires`, but that feels more in keeping with a minor version change, rather than a `0.1.1` patch release containing only a simple backwards-compatible fix (#56)