### PR TITLE
Use the 'set_invocation_id' function in spawn_setup

### DIFF
--- a/dbt_rpc/rpc/task_handler.py
+++ b/dbt_rpc/rpc/task_handler.py
@@ -74,6 +74,7 @@ class BootstrapProcess(dbt.flags.MP_CONTEXT.Process):
         user_config = None
         if self.task.config is not None:
             user_config = self.task.config.user_config
+        dbt.events.functions.set_invocation_id()
         dbt.flags.set_from_args(self.task.args, user_config)
         dbt.tracking.initialize_from_flags()
         # reload the active plugin


### PR DESCRIPTION
For the new logging framework we decoupled the invocation_id from the active_user in the tracking module. This calls the 'dbt.events.functionsset_invocation_id()' function in the '_spawn_setup' function to preserve the previous functionality of having the invocation_id change.