### PR TITLE
Save args in config when cli_vars is saved

### DIFF
--- a/dbt_rpc/task/cli.py
+++ b/dbt_rpc/task/cli.py
@@ -104,6 +104,7 @@ class RemoteRPCCli(RPCTask[RPCCliParameters]):
         dumped = yaml.safe_dump(self.config.cli_vars)
         if dumped != self.args.vars:
             self.real_task.args.vars = dumped
+            self.config.args = self.args
             if isinstance(self.real_task, RemoteManifestMethod):
                 self.real_task.manifest = ManifestLoader.get_full_manifest(
                     self.config, reset=True

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -410,4 +410,4 @@ def test_variable_injection_in_config(
     with querier_ctx as querier:
       results = querier.async_wait_for_result(querier.cli_args('run --vars \'test_variable: "9876"\''))
       assert len(results['results']) == 1
-      assert results['results'][0]['node']['compiled_sql'].trim() == 'select 9876 as id'
+      assert results['results'][0]['node']['compiled_sql'].strip() == 'select 9876 as id'


### PR DESCRIPTION
This is for bug #4583 in dbt-core, var not injected in dbt run snapshot from dbt run invocation in 1.0.0.