### PR TITLE
Make garbage collection configurable

### DIFF
--- a/dbt_rpc/rpc/gc.py
+++ b/dbt_rpc/rpc/gc.py
@@ -19,17 +19,11 @@ class GarbageCollector:
     def __init__(
         self,
         active_tasks: TaskHandlerMap,
-        settings: Optional[GCSettings] = None,
+        settings: GCSettings,
     ) -> None:
         self.active_tasks: TaskHandlerMap = active_tasks
-        self.settings: GCSettings
+        self.settings: GCSettings = settings
 
-        if settings is None:
-            self.settings = GCSettings(
-                maxsize=30, reapsize=15, auto_reap_age=timedelta(days=30)
-            )
-        else:
-            self.settings = settings
 
     def _remove_task_if_finished(self, task_id: TaskID) -> GCResultState:
         """Remove the task if it was finished. Raises a KeyError if the entry

--- a/dbt_rpc/rpc/gc.py
+++ b/dbt_rpc/rpc/gc.py
@@ -24,7 +24,6 @@ class GarbageCollector:
         self.active_tasks: TaskHandlerMap = active_tasks
         self.settings: GCSettings = settings
 
-
     def _remove_task_if_finished(self, task_id: TaskID) -> GCResultState:
         """Remove the task if it was finished. Raises a KeyError if the entry
         is removed during operation (so hold the lock).

--- a/dbt_rpc/rpc/gc.py
+++ b/dbt_rpc/rpc/gc.py
@@ -1,5 +1,5 @@
 import operator
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Optional, List, Iterable, Tuple
 
 import dbt.exceptions

--- a/dbt_rpc/rpc/gc.py
+++ b/dbt_rpc/rpc/gc.py
@@ -26,7 +26,7 @@ class GarbageCollector:
 
         if settings is None:
             self.settings = GCSettings(
-                maxsize=1000, reapsize=500, auto_reap_age=timedelta(days=30)
+                maxsize=30, reapsize=15, auto_reap_age=timedelta(days=30)
             )
         else:
             self.settings = settings

--- a/dbt_rpc/rpc/task_manager.py
+++ b/dbt_rpc/rpc/task_manager.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 import threading
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import (
     Any, Dict, Optional, List, Union, Set, Callable, Type
 )
@@ -30,7 +30,6 @@ from dbt_rpc.rpc.method import (
 # pick up our builtin methods
 import dbt_rpc.rpc.builtins  # noqa
 
-
 # import this to make sure our timedelta encoder is registered
 from dbt import helper_types  # noqa
 
@@ -39,6 +38,9 @@ WrappedHandler = Callable[..., Dict[str, Any]]
 
 
 SINGLE_THREADED_WEBSERVER = flags.env_set_truthy('DBT_SINGLE_THREADED_WEBSERVER')
+GC_MAXSIZE = int(flags.env_set_truthy('DBT_GC_MAXSIZE')) or 100
+GC_REAPSIZE = int(flags.env_set_truthy('DBT_GC_REAPSIZE')) or 50
+GC_AUTO_REAP_HOURS = int(flags.env_set_truthy('DBT_GC_AUTO_REAP_AGE')) or 24
 
 
 class UnconditionalError:
@@ -87,7 +89,12 @@ class TaskManager:
         self.manifest: Optional[Manifest] = None
         self._task_types: TaskTypes = task_types
         self.active_tasks: TaskHandlerMap = {}
-        self.gc = GarbageCollector(active_tasks=self.active_tasks)
+        gc_settings = GCSettings(
+                maxsize=GC_MAXSIZE,
+                reapsize=GC_REAPSIZE,
+                auto_reap_age=timedelta(hours=GC_AUTO_REAP_HOURS)
+            )
+        self.gc = GarbageCollector(active_tasks=self.active_tasks, settings=gc_settings)
         self.last_parse: LastParse = LastParse(state=ManifestStatus.Init)
         self._lock: flags.MP_CONTEXT.Lock = flags.MP_CONTEXT.Lock()
         self._reloader: Optional[ManifestReloader] = None

--- a/dbt_rpc/rpc/task_manager.py
+++ b/dbt_rpc/rpc/task_manager.py
@@ -38,9 +38,9 @@ WrappedHandler = Callable[..., Dict[str, Any]]
 
 
 SINGLE_THREADED_WEBSERVER = flags.env_set_truthy('DBT_SINGLE_THREADED_WEBSERVER')
-GC_MAXSIZE = int(flags.env_set_truthy('DBT_GC_MAXSIZE')) or 100
-GC_REAPSIZE = int(flags.env_set_truthy('DBT_GC_REAPSIZE')) or 50
-GC_AUTO_REAP_HOURS = int(flags.env_set_truthy('DBT_GC_AUTO_REAP_AGE')) or 24
+GC_MAXSIZE = int(flags.env_set_truthy('DBT_GC_MAXSIZE') or 100)
+GC_REAPSIZE = int(flags.env_set_truthy('DBT_GC_REAPSIZE') or 50)
+GC_AUTO_REAP_HOURS = int(flags.env_set_truthy('DBT_GC_AUTO_REAP_AGE') or 24)
 
 
 class UnconditionalError:

--- a/dbt_rpc/rpc/task_manager.py
+++ b/dbt_rpc/rpc/task_manager.py
@@ -38,9 +38,9 @@ WrappedHandler = Callable[..., Dict[str, Any]]
 
 
 SINGLE_THREADED_WEBSERVER = flags.env_set_truthy('DBT_SINGLE_THREADED_WEBSERVER')
-GC_MAXSIZE = int(flags.env_set_truthy('DBT_RPC_INTERNAL_GC_MAXSIZE') or 100)
-GC_REAPSIZE = int(flags.env_set_truthy('DBT_RPC_INTERNAL_GC_REAPSIZE') or 50)
-GC_AUTO_REAP_HOURS = int(flags.env_set_truthy('DBT_RPC_INTERNAL_GC_AUTO_REAP_AGE') or 24)
+GC_MAXSIZE = int(flags.env_set_truthy('DBT_RPC_INTERNAL_GC_MAXSIZE') or 1000)
+GC_REAPSIZE = int(flags.env_set_truthy('DBT_RPC_INTERNAL_GC_REAPSIZE') or 500)
+GC_AUTO_REAP_HOURS = int(flags.env_set_truthy('DBT_RPC_INTERNAL_GC_AUTO_REAP_AGE') or 24 * 30)
 
 
 class UnconditionalError:

--- a/dbt_rpc/rpc/task_manager.py
+++ b/dbt_rpc/rpc/task_manager.py
@@ -90,10 +90,10 @@ class TaskManager:
         self._task_types: TaskTypes = task_types
         self.active_tasks: TaskHandlerMap = {}
         gc_settings = GCSettings(
-                maxsize=GC_MAXSIZE,
-                reapsize=GC_REAPSIZE,
-                auto_reap_age=timedelta(hours=GC_AUTO_REAP_HOURS)
-            )
+            maxsize=GC_MAXSIZE,
+            reapsize=GC_REAPSIZE,
+            auto_reap_age=timedelta(hours=GC_AUTO_REAP_HOURS)
+        )
         self.gc = GarbageCollector(active_tasks=self.active_tasks, settings=gc_settings)
         self.last_parse: LastParse = LastParse(state=ManifestStatus.Init)
         self._lock: flags.MP_CONTEXT.Lock = flags.MP_CONTEXT.Lock()

--- a/dbt_rpc/rpc/task_manager.py
+++ b/dbt_rpc/rpc/task_manager.py
@@ -38,9 +38,9 @@ WrappedHandler = Callable[..., Dict[str, Any]]
 
 
 SINGLE_THREADED_WEBSERVER = flags.env_set_truthy('DBT_SINGLE_THREADED_WEBSERVER')
-GC_MAXSIZE = int(flags.env_set_truthy('DBT_GC_MAXSIZE') or 100)
-GC_REAPSIZE = int(flags.env_set_truthy('DBT_GC_REAPSIZE') or 50)
-GC_AUTO_REAP_HOURS = int(flags.env_set_truthy('DBT_GC_AUTO_REAP_AGE') or 24)
+GC_MAXSIZE = int(flags.env_set_truthy('DBT_RPC_INTERNAL_GC_MAXSIZE') or 100)
+GC_REAPSIZE = int(flags.env_set_truthy('DBT_RPC_INTERNAL_GC_REAPSIZE') or 50)
+GC_AUTO_REAP_HOURS = int(flags.env_set_truthy('DBT_RPC_INTERNAL_GC_AUTO_REAP_AGE') or 24)
 
 
 class UnconditionalError:


### PR DESCRIPTION
Resolves #75

Issue with #75 is that the TaskManager stores each task (before garbage collection), including the results and logs associated with that task. And For larger projects those results and logs could be huge. Scaling back on the number of tasks we can store will reduce peak memory usage