### PR TITLE
Break passenv parameters into separate lines to make tox happy again

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,10 @@ deps =
 
 [testenv:{py36,py37,py38,py39,py}]
 description = rpc testing
-passenv = DBT_* POSTGRES_TEST_* PYTEST_ADDOPTS
+passenv =
+  DBT_*
+  POSTGRES_TEST_*
+  PYTEST_ADDOPTS
 commands = {envpython} -m pytest {posargs}
 deps =
   -rdev-requirements.txt


### PR DESCRIPTION
Fixes #106

Update tox.ini to break passenv parameters onto separate lines.