### PR TITLE
Add new context argument to _get_responses method

### DIFF
--- a/dbt_rpc/rpc/response_manager.py
+++ b/dbt_rpc/rpc/response_manager.py
@@ -88,8 +88,8 @@ class ResponseManager(JSONRPCResponseManager):
             return cls.handle_request(request, dispatcher)
 
     @classmethod
-    def _get_responses(cls, requests, dispatcher):
-        for output in super()._get_responses(requests, dispatcher):
+    def _get_responses(cls, requests, dispatcher, context=None):
+        for output in super()._get_responses(requests, dispatcher, context):
             # if it's a result, check if it's a dbtClassMixin and if so call
             # to_dict
             if hasattr(output, 'result'):


### PR DESCRIPTION
Fixes #116.

From the linked issue, a recent modification to the json-rpc parent `JSONRPCResponseManager` https://github.com/pavlov99/json-rpc/pull/122/files#diff-71ff9d558b2e51825f517c97faa2f119ab0aaf26aaff43e36731719017cce06eR75 class adds a new argument that is causing an error in the overridden version in the custom dbt-rpc `ResponseManager` class.

This PR essentially just adds in the same context argument to the `_get_responses` method, which is being called from the parent `handle_request` method.