### PR TITLE
Bump version for release

### DIFF
--- a/dbt_rpc/rpc/task_handler.py
+++ b/dbt_rpc/rpc/task_handler.py
@@ -102,6 +102,11 @@ class BootstrapProcess(dbt.flags.MP_CONTEXT.Process):
             if not hasattr(self.task.args, 'selector'):
                 object.__setattr__(self.task.args, "selector", None)
                 object.__setattr__(self.task.args, "SELECTOR", None)
+            # pre-1.5 we always set populate_cache to True. This represent parity
+            # with the old behavior, not parity with core
+            if not hasattr(self.task.args, 'populate_cache'):
+                object.__setattr__(self.task.args, "populate_cache", True)
+
             rpc_exception = None
             result = None
             try:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 
 package_name = "dbt-rpc"
-package_version = "0.4.0b1"
+package_version = "0.4.0"
 description = """ A JSON RPC server that provides an interface to programmically interact with dbt projects. """
 
 
@@ -30,7 +30,7 @@ setup(
     },
     install_requires=[
         'json-rpc>=1.14,<2',
-        'dbt-core>=1.5.0b1'
+        'dbt-core>=1.5.0'
     ],
     zip_safe=False,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 
 package_name = "dbt-rpc"
-package_version = "0.4.0"
+package_version = "0.4.0rc1"
 description = """ A JSON RPC server that provides an interface to programmically interact with dbt projects. """
 
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     },
     install_requires=[
         'json-rpc>=1.14,<2',
-        'dbt-core>=1.5.0'
+        'dbt-core>=1.5.0b1'
     ],
     zip_safe=False,
     classifiers=[

--- a/tests/test_compile_sql.py
+++ b/tests/test_compile_sql.py
@@ -22,7 +22,7 @@ def test_rpc_run_sql_nohang(
     )
     with querier_ctx as querier:
         result = querier.async_wait_for_result(querier.compile_sql('select 1 as id', language='python'))
-        assert 'def ref(*args,dbt_load_df_function):' in result['results'][0]['compiled_sql']
+        assert 'dbt_load_df_function' in result['results'][0]['compiled_sql']
 
 @pytest.mark.supported('any')
 def test_rpc_compile_macro(


### PR DESCRIPTION
Only bumped rpc version but still including beta version of core.
We also hardcoded in dbt-rpc that cache is always going to be populated