### PR TITLE
update used gh actions ahead of set-output, node12 deprecation

### DIFF
--- a/.github/workflows/jira-creation.yml
+++ b/.github/workflows/jira-creation.yml
@@ -13,13 +13,13 @@ name: Jira Issue Creation
 on:
   issues:
     types: [opened, labeled]
-    
+
 permissions:
   issues: write
 
 jobs:
   call-label-action:
-    uses: dbt-labs/jira-actions/.github/workflows/jira-creation.yml@main
+    uses: dbt-labs/actions/.github/workflows/jira-creation.yml@main
     secrets:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/jira-creation.yml
+++ b/.github/workflows/jira-creation.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   call-label-action:
-    uses: dbt-labs/actions/.github/workflows/jira-creation.yml@main
+    uses: dbt-labs/actions/.github/workflows/jira-creation-actions.yml@main
     secrets:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/jira-label.yml
+++ b/.github/workflows/jira-label.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   call-label-action:
-    uses: dbt-labs/actions/.github/workflows/jira-label.yml@main
+    uses: dbt-labs/actions/.github/workflows/jira-label-actions.yml@main
     secrets:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/jira-label.yml
+++ b/.github/workflows/jira-label.yml
@@ -13,15 +13,15 @@ name: Jira Label Mirroring
 on:
   issues:
     types: [labeled, unlabeled]
-    
+
 permissions:
   issues: read
 
 jobs:
   call-label-action:
-    uses: dbt-labs/jira-actions/.github/workflows/jira-label.yml@main
+    uses: dbt-labs/actions/.github/workflows/jira-label.yml@main
     secrets:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
       JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
-    
+

--- a/.github/workflows/jira-transition.yml
+++ b/.github/workflows/jira-transition.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   call-label-action:
-    uses: dbt-labs/jira-actions/.github/workflows/jira-transition.yml@main
+    uses: dbt-labs/actions/.github/workflows/jira-transition.yml@main
     secrets:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/jira-transition.yml
+++ b/.github/workflows/jira-transition.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   call-label-action:
-    uses: dbt-labs/actions/.github/workflows/jira-transition.yml@main
+    uses: dbt-labs/actions/.github/workflows/jira-transition-actions.yml@main
     secrets:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,12 +51,12 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
 
       - name: Install python dependencies
         run: |
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
@@ -96,7 +96,7 @@ jobs:
           sudo -u postgres bash tests/setup_db.sh
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -117,12 +117,12 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
 
@@ -146,7 +146,7 @@ jobs:
         run: |
           check-wheel-contents dist/*.whl --ignore W007,W008
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: dist
           path: dist/
@@ -166,7 +166,7 @@ jobs:
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -176,7 +176,7 @@ jobs:
           python -m pip install --upgrade wheel
           python -m pip --version
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
Update versions of used Github Actions ahead of:

- [node12 deprecation](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) (Summer 2023)
- [set-output deprecation](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) (fully disabled on 31st May 2023)

Update `jira-*` github actions to be sourced from the [dbt-labs actions repo](https://github.com/dbt-labs/actions) instead of the [dbt-labs jira-actions repo](https://github.com/dbt-labs/jira-actions)