### PR TITLE
Cl/fix poll list result main

### DIFF
--- a/dbt_rpc/contracts/rpc.py
+++ b/dbt_rpc/contracts/rpc.py
@@ -787,6 +787,32 @@ class PollGetManifestResult(GetManifestResult, PollResult):
             elapsed=timing.elapsed,
         )
 
+@dataclass
+@schema_version('poll-remote-list-result', 1)
+class PollListResult(RemoteListResults, PollResult):
+    state: TaskHandlerState = field(
+        metadata=restrict_to(TaskHandlerState.Success,
+                             TaskHandlerState.Failed),
+    )
+
+    @classmethod
+    def from_result(
+        cls: Type['PollListResult'],
+        base: RemoteListResults,
+        tags: TaskTags,
+        timing: TaskTiming,
+        logs: List[LogMessage],
+    ) -> 'PollListResult':
+        return cls(
+            output=base.output,
+            logs=logs,
+            tags=tags,
+            state=timing.state,
+            start=timing.start,
+            end=timing.end,
+            elapsed=timing.elapsed,
+        )
+
 
 @dataclass
 @schema_version("poll-remote-freshness-result", 1)

--- a/dbt_rpc/contracts/rpc.py
+++ b/dbt_rpc/contracts/rpc.py
@@ -787,6 +787,7 @@ class PollGetManifestResult(GetManifestResult, PollResult):
             elapsed=timing.elapsed,
         )
 
+
 @dataclass
 @schema_version('poll-remote-list-result', 1)
 class PollListResult(RemoteListResults, PollResult):

--- a/dbt_rpc/rpc/builtins.py
+++ b/dbt_rpc/rpc/builtins.py
@@ -5,6 +5,8 @@ from typing import Type, Union, Any, List, Dict
 
 import dbt.exceptions
 from dbt_rpc.contracts.rpc import (
+    PollListResult,
+    RemoteListResults,
     TaskTags,
     StatusParameters,
     ReloadParameters,
@@ -150,6 +152,7 @@ def poll_complete(
             PollRunOperationCompleteResult,
             PollGetManifestResult,
             PollFreshnessResult,
+            PollListResult,
         ]
     ]
 
@@ -170,6 +173,8 @@ def poll_complete(
         cls = PollGetManifestResult
     elif isinstance(result, RemoteFreshnessResult):
         cls = PollFreshnessResult
+    elif isinstance(result, RemoteListResults):
+        cls = PollListResult
     else:
         raise dbt.exceptions.InternalException(
             "got invalid result in poll_complete: {}".format(result)

--- a/dbt_rpc/rpc/builtins.py
+++ b/dbt_rpc/rpc/builtins.py
@@ -56,7 +56,7 @@ class GC(RemoteBuiltinMethod[GCParameters, GCResult]):
 
     def handle_request(self) -> GCResult:
         if self.params is None:
-            raise dbt.exceptions.InternalException("GC: params not set")
+            raise dbt.exceptions.DbtInternalError("GC: params not set")
         return self.task_manager.gc_safe(
             task_ids=self.params.task_ids,
             before=self.params.before,
@@ -72,7 +72,7 @@ class Kill(RemoteBuiltinMethod[KillParameters, KillResult]):
 
     def handle_request(self) -> KillResult:
         if self.params is None:
-            raise dbt.exceptions.InternalException("Kill: params not set")
+            raise dbt.exceptions.DbtInternalError("Kill: params not set")
         result = KillResult()
         task: RequestTaskHandler
         try:
@@ -119,7 +119,7 @@ class PS(RemoteBuiltinMethod[PSParameters, PSResult]):
 
     def keep(self, row: TaskRow):
         if self.params is None:
-            raise dbt.exceptions.InternalException("PS: params not set")
+            raise dbt.exceptions.DbtInternalError("PS: params not set")
         if row.state.finished and self.params.completed:
             return True
         elif not row.state.finished and self.params.active:
@@ -138,7 +138,7 @@ def poll_complete(
     timing: TaskTiming, result: Any, tags: TaskTags, logs: List[LogMessage]
 ) -> PollResult:
     if timing.state not in (TaskHandlerState.Success, TaskHandlerState.Failed):
-        raise dbt.exceptions.InternalException(
+        raise dbt.exceptions.DbtInternalError(
             f"got invalid result state in poll_complete: {timing.state}"
         )
 
@@ -176,7 +176,7 @@ def poll_complete(
     elif isinstance(result, RemoteListResults):
         cls = PollListResult
     else:
-        raise dbt.exceptions.InternalException(
+        raise dbt.exceptions.DbtInternalError(
             "got invalid result in poll_complete: {}".format(result)
         )
     return cls.from_result(result, tags, timing, logs)
@@ -194,7 +194,7 @@ class Poll(RemoteBuiltinMethod[PollParameters, PollResult]):
 
     def handle_request(self) -> PollResult:
         if self.params is None:
-            raise dbt.exceptions.InternalException("Poll: params not set")
+            raise dbt.exceptions.DbtInternalError("Poll: params not set")
         task_id = self.params.request_token
         task: RequestTaskHandler = self.task_manager.get_request(task_id)
 
@@ -221,7 +221,7 @@ class Poll(RemoteBuiltinMethod[PollParameters, PollResult]):
         elif state == TaskHandlerState.Error:
             err = task.error
             if err is None:
-                exc = dbt.exceptions.InternalException(
+                exc = dbt.exceptions.DbtInternalError(
                     f"At end of task {task_id}, error state but error is None"
                 )
                 raise RPCException.from_error(
@@ -232,7 +232,7 @@ class Poll(RemoteBuiltinMethod[PollParameters, PollResult]):
             raise err
         elif state in (TaskHandlerState.Success, TaskHandlerState.Failed):
             if task.result is None:
-                exc = dbt.exceptions.InternalException(
+                exc = dbt.exceptions.DbtInternalError(
                     f"At end of task {task_id}, state={state} but result is " "None"
                 )
                 raise RPCException.from_error(
@@ -251,7 +251,7 @@ class Poll(RemoteBuiltinMethod[PollParameters, PollResult]):
                 elapsed=timing.elapsed,
             )
         else:
-            exc = dbt.exceptions.InternalException(
+            exc = dbt.exceptions.DbtInternalError(
                 f"Got unknown value state={state} for task {task_id}"
             )
             raise RPCException.from_error(dbt_error(exc, logs=_dict_logs(task_logs)))

--- a/dbt_rpc/rpc/gc.py
+++ b/dbt_rpc/rpc/gc.py
@@ -74,7 +74,7 @@ class GarbageCollector:
         except KeyError:
             # someone was mutating tasks while we had the lock, that's
             # not right!
-            raise dbt.exceptions.InternalException(
+            raise dbt.exceptions.DbtInternalError(
                 'Got a KeyError for task uuid={} during gc'
                 .format(task_id)
             )

--- a/dbt_rpc/rpc/response_manager.py
+++ b/dbt_rpc/rpc/response_manager.py
@@ -60,7 +60,7 @@ class RequestDispatcher(Dict[str, Callable[..., Dict[str, Any]]]):
                 self.manager, handler, self.http_request, self.json_rpc_request
             )
         else:
-            raise dbt.exceptions.InternalException(
+            raise dbt.exceptions.DbtInternalError(
                 f'Got an invalid handler from get_handler. Expected None, '
                 f'callable, or RemoteMethod, got {handler}'
             )

--- a/dbt_rpc/rpc/task_handler_protocol.py
+++ b/dbt_rpc/rpc/task_handler_protocol.py
@@ -42,14 +42,14 @@ class TaskHandlerProtocol(Protocol):
 
     def _assert_started(self) -> datetime:
         if self.started is None:
-            raise dbt.exceptions.InternalException(
+            raise dbt.exceptions.DbtInternalError(
                 'task handler started but start time is not set'
             )
         return self.started
 
     def _assert_ended(self) -> datetime:
         if self.ended is None:
-            raise dbt.exceptions.InternalException(
+            raise dbt.exceptions.DbtInternalError(
                 'task handler finished but end time is not set'
             )
         return self.ended

--- a/dbt_rpc/rpc/task_manager.py
+++ b/dbt_rpc/rpc/task_manager.py
@@ -161,7 +161,7 @@ class TaskManager:
             return ParseError(self.last_parse.error)
         else:
             if self.manifest is None:
-                raise dbt.exceptions.InternalException(
+                raise dbt.exceptions.DbtInternalError(
                     f'Manifest should not be None if the last parse state is '
                     f'{state}'
                 )
@@ -179,7 +179,7 @@ class TaskManager:
             elif issubclass(task, RemoteMethod):
                 return task(deepcopy(self.args), self.config)
             else:
-                raise dbt.exceptions.InternalException(
+                raise dbt.exceptions.DbtInternalError(
                     f'Got a task with an invalid type! {task} with method '
                     f'name {method_name} has a type of {task.__class__}, '
                     f'should be a RemoteMethod'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 
 package_name = "dbt-rpc"
-package_version = "0.4.0"
+package_version = "0.4.1"
 description = """ A JSON RPC server that provides an interface to programmically interact with dbt projects. """
 
 


### PR DESCRIPTION
Tested by adding the following code to `builtins.py` at `class Poll(RemoteBuiltinMethod[PollParameters, PollResult]):` to swap out task id
```python
        # switch to the task id of list command
        test = [key for key in self.task_manager.active_tasks]
        test.remove(task_id)
        task_id = test[0]
```

And the test we run looks like 
```python
import pytest
from .util import (
    get_querier,
    ProjectDefinition,
)


@pytest.mark.supported('postgres')
def test_rpc_run_threads(
    project_root, profiles_root, dbt_profile, unique_schema
):
    project = ProjectDefinition(
        models={'my_model.sql': 'select 1 as id'}
    )
    querier_ctx = get_querier(
        project_def=project,
        project_dir=project_root,
        profiles_dir=profiles_root,
        schema=unique_schema,
    )
    with querier_ctx as querier:
        # run a run so that we have a request token
        run_result = querier.run()
        # run a list command so we have a task going
        result = querier.list()
        # there's code added in poll to swap out the request token so we are actually
        # getting the list command result back
        result1 = querier.poll(run_result['result']['request_token'])
        assert 'error' not in result1
```