### PR TITLE
Fix execution of "defer" command

### DIFF
--- a/dbt_rpc/contracts/rpc.py
+++ b/dbt_rpc/contracts/rpc.py
@@ -343,7 +343,7 @@ class RunOperationCompleteResult(
             results=base.results,
             elapsed_time=base.elapsed_time,
             logs=logs,
-            success=all(result.status == NodeStatus.Success for result in base.results),
+            success=base.success,
         )
 
 

--- a/dbt_rpc/contracts/rpc.py
+++ b/dbt_rpc/contracts/rpc.py
@@ -10,7 +10,6 @@ from dbt.dataclass_schema import dbtClassMixin, StrEnum
 from dbt.contracts.graph.nodes import ResultNode
 from dbt.contracts.graph.manifest import WritableManifest
 from dbt.contracts.results import (
-    NodeStatus,
     RunResult,
     RunResultsArtifact,
     TimingInfo,

--- a/dbt_rpc/contracts/rpc.py
+++ b/dbt_rpc/contracts/rpc.py
@@ -342,7 +342,6 @@ class RunOperationCompleteResult(
             generated_at=base.generated_at,
             results=base.results,
             elapsed_time=base.elapsed_time,
-            args=base.args,
             logs=logs,
             success=all(result.status == NodeStatus.Success for result in base.results),
         )

--- a/dbt_rpc/contracts/rpc.py
+++ b/dbt_rpc/contracts/rpc.py
@@ -86,6 +86,7 @@ class RPCRunParameters(RPCParameters):
     selector: Optional[str] = None
     state: Optional[str] = None
     defer: Optional[bool] = None
+    favor_state: Optional[bool] = None
 
 
 @dataclass
@@ -103,6 +104,7 @@ class RPCTestParameters(RPCCompileParameters):
     schema: bool = False
     state: Optional[str] = None
     defer: Optional[bool] = None
+    favor_state: Optional[bool] = None
 
 
 @dataclass
@@ -130,6 +132,7 @@ class RPCBuildParameters(RPCParameters):
     selector: Optional[str] = None
     state: Optional[str] = None
     defer: Optional[bool] = None
+    favor_state: Optional[bool] = None
 
 
 @dataclass

--- a/dbt_rpc/rpc/task_handler.py
+++ b/dbt_rpc/rpc/task_handler.py
@@ -482,6 +482,7 @@ class RequestTaskHandler(threading.Thread, TaskHandlerProtocol):
     def handle(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
         self.started = datetime.utcnow()
         self.state = TaskHandlerState.Initializing
+        print(f"---in RequestTaskHandler.handle. kwargs: {kwargs}")
         self.task_kwargs = kwargs
 
         with SetArgsStateHandler(self):

--- a/dbt_rpc/rpc/task_handler.py
+++ b/dbt_rpc/rpc/task_handler.py
@@ -84,7 +84,7 @@ class BootstrapProcess(dbt.flags.MP_CONTEXT.Process):
 
     def task_exec(self) -> None:
         """task_exec runs first inside the child process"""
-        if type(self.task) != RemoteListTask:
+        if type(self.task) is not RemoteListTask:
             # TODO: find another solution for this.. in theory it stops us from
             # being able to kill RemoteListTask processes
             signal.signal(signal.SIGTERM, sigterm_handler)
@@ -482,7 +482,6 @@ class RequestTaskHandler(threading.Thread, TaskHandlerProtocol):
     def handle(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
         self.started = datetime.utcnow()
         self.state = TaskHandlerState.Initializing
-        print(f"---in RequestTaskHandler.handle. kwargs: {kwargs}")
         self.task_kwargs = kwargs
 
         with SetArgsStateHandler(self):

--- a/dbt_rpc/task/base.py
+++ b/dbt_rpc/task/base.py
@@ -8,7 +8,6 @@ from dbt_rpc.contracts.rpc import (
 )
 from dbt.task.runnable import GraphRunnableTask
 from dbt_rpc.rpc.method import RemoteManifestMethod, Parameters
-from typing import AbstractSet
 
 
 RESULT_TYPE_MAP = {

--- a/dbt_rpc/task/base.py
+++ b/dbt_rpc/task/base.py
@@ -31,13 +31,6 @@ class RPCTask(
         # we started out with a manifest!
         pass
 
-    def defer_to_manifest(self, adapter, selected_uids: AbstractSet[str]):
-        # https://github.com/dbt-labs/dbt-core/pull/6488
-        # abstract method added to GraphRunnableTask
-        # bacause of how we do multiple inheritance for project commands,
-        # this will be overridden by task-specific methods
-        pass
-
     def get_result(
         self, results, elapsed_time, generated_at
     ) -> RemoteExecutionResult:

--- a/dbt_rpc/task/cli.py
+++ b/dbt_rpc/task/cli.py
@@ -1,7 +1,7 @@
 import abc
 import shlex
 from dbt.clients.yaml_helper import Dumper, yaml  # noqa: F401
-from typing import Type, Optional
+from typing import Type, Optional, AbstractSet
 
 from dbt_rpc.contracts.rpc import RPCCliParameters
 
@@ -141,3 +141,6 @@ class RemoteRPCCli(RPCTask[RPCCliParameters]):
             # failure
             return False
         return self.real_task.interpret_results(results)
+
+    def defer_to_manifest(self, adapter, selected_uids: AbstractSet[str]):
+        return self.real_task.defer_to_manifest(self, adapter, selected_uids)

--- a/dbt_rpc/task/project_commands.py
+++ b/dbt_rpc/task/project_commands.py
@@ -109,6 +109,10 @@ class RemoteRunProjectTask(RPCCommandTask[RPCRunParameters], RunTask):
             self.args.defer = get_flags().DEFER
         else:
             self.args.defer = params.defer
+        if params.favor_state is None:
+            self.args.favor_state = False
+        else:
+            self.args.favor_state = params.favor_state
 
         self.args.state = state_path(params.state)
         self.set_previous_state()
@@ -335,6 +339,10 @@ class RemoteBuildProjectTask(RPCCommandTask[RPCBuildParameters], BuildTask):
             self.args.defer = get_flags().DEFER
         else:
             self.args.defer = params.defer
+        if params.favor_state is None:
+            self.args.favor_state = False
+        else:
+            self.args.favor_state = params.favor_state
 
         self.args.state = state_path(params.state)
         self.set_previous_state()

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-postgres&subdirectory=plugins/postgres
+git+https://github.com/dbt-labs/dbt-core.git@1.5.latest#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-core.git@1.5.latest#egg=dbt-postgres&subdirectory=plugins/postgres
 
 flake8
 pytest

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
             "dbt-rpc = dbt_rpc.__main__:main",
         ],
     },
-    install_requires=["json-rpc>=1.14,<2", "dbt-core>=1.5.0"],
+    install_requires=["json-rpc>=1.14,<2", "dbt-core>=1.5.0,<1.6.0"],
     zip_safe=False,
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
Remove "defer_to_manifest" method from RPCTask and add it to RemoteRPCCLI. Add the "favor_state" parameter.

In addition a couple of errors had crept in because some changes were made when the boundary between 1.5 and main was fuzzy, so we needed to do some fixup there.