### PR TITLE
Fix execution of "defer" command for dbt-core 1.4

### DIFF
--- a/dbt_rpc/contracts/rpc.py
+++ b/dbt_rpc/contracts/rpc.py
@@ -85,6 +85,7 @@ class RPCRunParameters(RPCParameters):
     selector: Optional[str] = None
     state: Optional[str] = None
     defer: Optional[bool] = None
+    favor_state: Optional[bool] = None
 
 
 @dataclass
@@ -102,6 +103,7 @@ class RPCTestParameters(RPCCompileParameters):
     schema: bool = False
     state: Optional[str] = None
     defer: Optional[bool] = None
+    favor_state: Optional[bool] = None
 
 
 @dataclass
@@ -129,6 +131,7 @@ class RPCBuildParameters(RPCParameters):
     selector: Optional[str] = None
     state: Optional[str] = None
     defer: Optional[bool] = None
+    favor_state: Optional[bool] = None
 
 
 @dataclass

--- a/dbt_rpc/rpc/task_handler.py
+++ b/dbt_rpc/rpc/task_handler.py
@@ -83,7 +83,7 @@ class BootstrapProcess(dbt.flags.MP_CONTEXT.Process):
 
     def task_exec(self) -> None:
         """task_exec runs first inside the child process"""
-        if type(self.task) != RemoteListTask:
+        if type(self.task) is not RemoteListTask:
             # TODO: find another solution for this.. in theory it stops us from
             # being able to kill RemoteListTask processes
             signal.signal(signal.SIGTERM, sigterm_handler)

--- a/dbt_rpc/task/base.py
+++ b/dbt_rpc/task/base.py
@@ -10,7 +10,6 @@ from dbt_rpc.contracts.rpc import (
 )
 from dbt.task.runnable import GraphRunnableTask
 from dbt_rpc.rpc.method import RemoteManifestMethod, Parameters
-from typing import AbstractSet
 
 
 RESULT_TYPE_MAP = {

--- a/dbt_rpc/task/base.py
+++ b/dbt_rpc/task/base.py
@@ -34,13 +34,6 @@ class RPCTask(
         # we started out with a manifest!
         pass
 
-    def defer_to_manifest(self, adapter, selected_uids: AbstractSet[str]):
-        # https://github.com/dbt-labs/dbt-core/pull/6488
-        # abstract method added to GraphRunnableTask
-        # bacause of how we do multiple inheritance for project commands,
-        # this will be overridden by task-specific methods
-        pass
-
     def get_result(
         self, results, elapsed_time, generated_at
     ) -> RemoteExecutionResult:

--- a/dbt_rpc/task/cli.py
+++ b/dbt_rpc/task/cli.py
@@ -1,7 +1,7 @@
 import abc
 import shlex
 from dbt.clients.yaml_helper import Dumper, yaml  # noqa: F401
-from typing import Type, Optional
+from typing import Type, Optional, AbstractSet
 
 
 from dbt.config.utils import parse_cli_vars
@@ -125,3 +125,6 @@ class RemoteRPCCli(RPCTask[RPCCliParameters]):
             # failure
             return False
         return self.real_task.interpret_results(results)
+
+    def defer_to_manifest(self, adapter, selected_uids: AbstractSet[str]):
+        return self.real_task.defer_to_manifest(self, adapter, selected_uids)

--- a/dbt_rpc/task/project_commands.py
+++ b/dbt_rpc/task/project_commands.py
@@ -110,6 +110,10 @@ class RemoteRunProjectTask(RPCCommandTask[RPCRunParameters], RunTask):
             self.args.defer = flags.DEFER_MODE
         else:
             self.args.defer = params.defer
+        if params.favor_state is None:
+            self.args.favor_state = False
+        else:
+            self.args.favor_state = params.favor_state
 
         self.args.state = state_path(params.state)
         self.set_previous_state()
@@ -335,6 +339,10 @@ class RemoteBuildProjectTask(RPCCommandTask[RPCBuildParameters], BuildTask):
             self.args.defer = flags.DEFER_MODE
         else:
             self.args.defer = params.defer
+        if params.favor_state is None:
+            self.args.favor_state = False
+        else:
+            self.args.favor_state = params.favor_state
 
         self.args.state = state_path(params.state)
         self.set_previous_state()


### PR DESCRIPTION
For ticket #147 

Remove "defer_to_manifest" method from RPCTask and add it to RemoteRPCCLI. Add the "favor_state" parameter.

